### PR TITLE
Add built-in target riscv32im-unknown-none

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The Rust Programming Language
+# The Rust Programming Language (with RISC-V support)
 
 This is the main source code repository for [Rust]. It contains the compiler,
 standard library, and documentation.

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -236,6 +236,8 @@ supported_targets! {
     ("armv7-unknown-cloudabi-eabihf", armv7_unknown_cloudabi_eabihf),
     ("i686-unknown-cloudabi", i686_unknown_cloudabi),
     ("x86_64-unknown-cloudabi", x86_64_unknown_cloudabi),
+
+    ("riscv32im-unknown-none", riscv32im_unknown_none),
 }
 
 /// Everything `rustc` knows about how to compile for a specific target.

--- a/src/librustc_back/target/riscv32im_unknown_none.rs
+++ b/src/librustc_back/target/riscv32im_unknown_none.rs
@@ -1,0 +1,44 @@
+use {LinkerFlavor, PanicStrategy};
+use target::{Target, TargetOptions, TargetResult};
+use syntax::abi::{Abi};
+
+pub fn target() -> TargetResult {
+    Ok(Target {
+        data_layout: "e-m:e-p:32:32-i64:64-n32-S128".to_string(),
+        llvm_target: "riscv32".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "32".to_string(),
+        target_c_int_width: "32".to_string(),
+        target_os: "none".to_string(),
+        target_env: "".to_string(),
+        target_vendor: "unknown".to_string(),
+        arch: "riscv".to_string(),
+        linker_flavor: LinkerFlavor::Ld,
+
+
+        options: TargetOptions {
+            linker: Some("ld.lld".to_string()),
+            cpu: "generic-rv32".to_string(),
+            max_atomic_width: Some(0),
+            features: "+m".to_string(),
+            executables: true,
+            panic_strategy: PanicStrategy::Abort,
+            relocation_model: "static".to_string(),
+            abi_blacklist: vec![
+                Abi::Cdecl,
+                Abi::Stdcall,
+                Abi::Fastcall,
+                Abi::Vectorcall,
+                Abi::Thiscall,
+                Abi::Aapcs,
+                Abi::Win64,
+                Abi::SysV64,
+                Abi::PtxKernel,
+                Abi::Msp430Interrupt,
+                Abi::X86Interrupt,
+            ],
+            .. Default::default()
+        },
+    })
+}
+


### PR DESCRIPTION
I added a built-in target for RV32IM without OS, because I think it more preferable than using the same custom target json for many projects. @dvc94ch, what do you think?
