### PR TITLE
Add riscv32imac_unknown_none target

### DIFF
--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -240,6 +240,7 @@ supported_targets! {
 
     ("riscv32i-unknown-none", riscv32i_unknown_none),
     ("riscv32ia-unknown-none", riscv32ia_unknown_none),
+    ("riscv32imac-unknown-none", riscv32imac_unknown_none),
 }
 
 /// Everything `rustc` knows about how to compile for a specific target.

--- a/src/librustc_back/target/riscv32imac_unknown_none.rs
+++ b/src/librustc_back/target/riscv32imac_unknown_none.rs
@@ -1,0 +1,43 @@
+use {LinkerFlavor, PanicStrategy};
+use target::{Target, TargetOptions, TargetResult};
+use syntax::abi::{Abi};
+
+pub fn target() -> TargetResult {
+    Ok(Target {
+        data_layout: "e-m:e-p:32:32-i64:64-n32-S128".to_string(),
+        llvm_target: "riscv32".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "32".to_string(),
+        target_c_int_width: "32".to_string(),
+        target_os: "none".to_string(),
+        target_env: "".to_string(),
+        target_vendor: "unknown".to_string(),
+        arch: "riscv".to_string(),
+        linker_flavor: LinkerFlavor::Ld,
+
+
+        options: TargetOptions {
+            linker: Some("ld.lld".to_string()),
+            cpu: "generic-rv32".to_string(),
+            max_atomic_width: Some(32),
+            features: "+m,+a,+c".to_string(),
+            executables: true,
+            panic_strategy: PanicStrategy::Abort,
+            relocation_model: "static".to_string(),
+            abi_blacklist: vec![
+                Abi::Cdecl,
+                Abi::Stdcall,
+                Abi::Fastcall,
+                Abi::Vectorcall,
+                Abi::Thiscall,
+                Abi::Aapcs,
+                Abi::Win64,
+                Abi::SysV64,
+                Abi::PtxKernel,
+                Abi::Msp430Interrupt,
+                Abi::X86Interrupt,
+            ],
+            .. Default::default()
+        },
+    })
+}


### PR DESCRIPTION
Not sure if this is the right approach...

I started out building for the riscv32ia-unknown-none target, but I hit a linker failure due to missing `__mulsi3` symbol. Eventually I figured out that meant the compiler thought my CPU had no multiply instructions (it does, it's the Hifive1).